### PR TITLE
HDP Generic Handler

### DIFF
--- a/hdp-generic-alert-handler/README.md
+++ b/hdp-generic-alert-handler/README.md
@@ -1,0 +1,19 @@
+This workflow is a handler for ANY HDP event. It only uses the data that is guaranteed to be present in every webhook. More specific handlers are possible, but this is a great tool to get started with HDP + Relay.  
+
+If you have been brought here from the HDP UI, and aren't familiar with Relay, please read [this](https://relay.sh/docs/getting-started/) to understand Relay first.
+
+## Prerequisites
+
+Before you run this workflow, you will need the following:
+- A working HDP installation.
+- A [Slack](https://slack.com/) workspace and an appropriate channel to send notifications to.
+
+# Configure the workflow
+
+First, create a Slack connection in Relay. If you're running into issues, try creating it from the "Connections" bar on the left, instead of directly in a workflow, which sometimes gives UUID-related errors.
+Second, clone this workflow into your own Relay account, using the "Try this workflow" button, while also replacing the slack-connection on line 26 with the name of your own slack connection. Also, make sure to set your bot's username, and the channel you would like the HDP to send messages to.
+
+## Configure the HDP
+
+After you have created this workflow in your Relay account, copy the URL for the webhook trigger. Then, visit the Webhook setup page in your HDP settings. You can issue a test webhook from this page, using the URL you copied here.  
+If your test webhook arrives in your slack channel, you're done! You can now set up alerts in your HDP. If you'd like more information in your alerts, like about which attribute changed, or which nodes were affected, you can use Relay to extract more specific data.

--- a/hdp-generic-alert-handler/hdp_generic_alert_handler.yaml
+++ b/hdp-generic-alert-handler/hdp_generic_alert_handler.yaml
@@ -1,0 +1,36 @@
+## Full guide available at https://relay.sh/docs/getting-started
+apiVersion: v1
+summary: This is a generic handler for any HDP event type. You can make your own handlers for more specific events.
+parameters:
+  message:
+    default: "Hello from the HDP!"
+  url:
+    default: ""
+  username:
+    default: "HDP Via Relay"
+  channel:
+    default: "#hdp-alerts"
+triggers:
+- name: hdp-generic-alert-webhook
+  source:
+    type: webhook
+    image: relaysh/stdlib-trigger-json
+  binding:
+    parameters:
+      message: !Data message
+      url: !Data url
+steps:
+- name: slack-message-send
+  image: relaysh/slack-step-message-send
+  spec:
+    connection: !Connection [slack, slack-connection]
+    blocks: >
+      [{
+        "type": "section", 
+        "text": {
+          "type": "mrkdwn",
+          "text": "${parameters.message} - <${parameters.url}|click here to view more.>"
+        }
+      }]
+    username: !Parameter username
+    channel: !Parameter channel


### PR DESCRIPTION
Add the workflow example for a handler of any HDP event - specifics need to be handled by smarter/more specific webhook triggers.

This workflow uses only the required HDP webhook trigger parameters - a human-readable message string, and a URL to a HDP dashboard page. 

It is quite simple - it formats these two fields into a slack message, and sends them using a Relay Slack connection.

We plan to expand the arsenal of HDP workflows soon, but since this one is capable of handling every trigger, even generically, we think that adding it to Relay's workflow library will really help users get started both with Relay as an action engine, and with HDP alerts.