### PR TITLE
Update filter instances to exit without error if no instances

### DIFF
--- a/ec2-reaper/filter-instances.py
+++ b/ec2-reaper/filter-instances.py
@@ -153,7 +153,7 @@ if __name__ == '__main__':
         raw_instances = relay.get(D.instances)
     except:
         print('No instances found. Exiting.')
-        exit(1)
+        exit(0)
 
     instances = filter(lambda i: i['State']['Name'] == 'running', raw_instances)
     for instance in instances:


### PR DESCRIPTION
This changes the exit code on line 156 from a 1 to a 0 so that this script behaves the same way as the describe-instances steps that does not 'fail' if there are no instances.